### PR TITLE
modules/nixos: add linkerOptions option

### DIFF
--- a/modules/nixos/default.nix
+++ b/modules/nixos/default.nix
@@ -214,6 +214,15 @@ in {
             mkdir -p /var/lib/hjem
 
             for manifest in ${manifests}/*; do
+              # This is needed because cue expects HOME and XDG_CACHE_HOME to be set
+              user="$(basename $manifest | cut -d'-' -f2 | cut -d'.' -f1)"
+              HOME="/home/$user"
+              XDG_CACHE_HOME="$HOME/.cache"
+
+              env HOME=$HOME XDG_CACHE_HOME=$XDG_CACHE_HOME ${pkgs.cue}/bin/cue vet -c ${../../manifest/v1.cue} $manifest
+            done
+
+            for manifest in ${manifests}/*; do
               if [ ! -f /var/lib/hjem/$(basename $manifest) ]; then
                 ${linker} activate $manifest
                 continue

--- a/tests/linker.nix
+++ b/tests/linker.nix
@@ -2,6 +2,7 @@ let
   userHome = "/home/alice";
 in
   (import ./lib) {
+<<<<<<< HEAD
     name = "hjem-linker";
     nodes = {
       node1 = {

--- a/tests/linker.nix
+++ b/tests/linker.nix
@@ -2,7 +2,6 @@ let
   userHome = "/home/alice";
 in
   (import ./lib) {
-<<<<<<< HEAD
     name = "hjem-linker";
     nodes = {
       node1 = {


### PR DESCRIPTION
add a linkerOptions option, intended to be set by external linker modules so they may extend the interface/capabilities of hjem.